### PR TITLE
Исправление ошибки возникающей при работе с netcoreapp2.1.

### DIFF
--- a/LinqDynamicFilterBuilder/ExpressionExtractor.cs
+++ b/LinqDynamicFilterBuilder/ExpressionExtractor.cs
@@ -6,7 +6,7 @@ namespace LinqDynamicFilterBuilder
 {
     public class ExpressionExtractor
     {
-        private static readonly MethodInfo ContainsMethod = typeof(string).GetTypeInfo().GetMethod("Contains");
+        private static readonly MethodInfo ContainsMethod = typeof(string).GetTypeInfo().GetMethod("Contains", new Type[] { typeof(string) });
         private static readonly MethodInfo StartsWithMethod = typeof(string).GetTypeInfo().GetMethod("StartsWith", new Type[] { typeof(string) });
         private static readonly MethodInfo EndsWithMethod = typeof(string).GetTypeInfo().GetMethod("EndsWith", new Type[] { typeof(string) });
 

--- a/LinqDynamicFilterBuilder/LinqDynamicFilterBuilder.csproj
+++ b/LinqDynamicFilterBuilder/LinqDynamicFilterBuilder.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <AssemblyVersion>0.0.0.4</AssemblyVersion>
+    <AssemblyVersion>0.0.0.5</AssemblyVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Bam.LinqDynamicFilterBuilder</PackageId>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
     <Authors>Andrey Berezniker</Authors>
     <Company>Andrey Berezniker</Company>
     <Product>Linq Dynamic Filter Builder</Product>
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder/blob/master/LICENSE.md</PackageLicenseUrl>
-    <FileVersion>0.0.0.4</FileVersion>
+    <FileVersion>0.0.0.5</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
При портировании приложений использующих данную библиотеку с netcoreapp2.0 на netcoreapp2.1 наткнулся на ошибку:

> System.TypeInitializationException: The type initializer for 'LinqDynamicFilterBuilder.ExpressionExtractor' threw an exception. ---> System.Reflection.AmbiguousMatchException: Ambiguous match found.

Здесь её исправление и небольшое изменение в файле проекта.