### PR TITLE
Использование условного AndAlso оператора вместо побитового And

### DIFF
--- a/LinqDynamicFilterBuilder/ExpressionBuilder.cs
+++ b/LinqDynamicFilterBuilder/ExpressionBuilder.cs
@@ -32,7 +32,7 @@ namespace LinqDynamicFilterBuilder
                         exp = ExpressionExtractor.GetExpression<T>(param, expressionFilter);
                     else
                     {
-                        exp = Expression.And(exp, ExpressionExtractor.GetExpression<T>(param, expressionFilter));
+                        exp = Expression.AndAlso(exp, ExpressionExtractor.GetExpression<T>(param, expressionFilter));
                     }
                 }
             }

--- a/LinqDynamicFilterBuilder/LinqDynamicFilterBuilder.csproj
+++ b/LinqDynamicFilterBuilder/LinqDynamicFilterBuilder.csproj
@@ -11,6 +11,6 @@
     <PackageProjectUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/BigApple1988/LinqDynamicFilterBuilder/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Version>0.0.5</Version>
+    <Version>0.0.6</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Обнаружил, что при конструировании фильтра используется побитовый оператор из-за которого Linq генерирует неоптимальные запросы. Нужно использовать условный. Тогда запросы хорошие.